### PR TITLE
M2-00: ベーステンプレートとテンプレート基盤の整備

### DIFF
--- a/fiction_sns/settings.py
+++ b/fiction_sns/settings.py
@@ -67,7 +67,7 @@ ROOT_URLCONF = 'fiction_sns.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -128,6 +128,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATICFILES_DIRS = [BASE_DIR / 'static']
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/home/views.py
+++ b/home/views.py
@@ -1,5 +1,5 @@
-from django.http import HttpResponse
+from django.shortcuts import render
 
 
 def index(request):
-    return HttpResponse("Fictions flow SNS（仮）")
+    return render(request, "home/index.html")

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,0 +1,84 @@
+:root {
+  --bg: #f4f1ea;
+  --paper: #fffdfa;
+  --ink: #1f2521;
+  --accent: #2a6f5a;
+  --line: #d9d2c3;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  color: var(--ink);
+  background: linear-gradient(180deg, #f3eee3 0%, #ece7de 100%);
+}
+
+.container {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+  padding: 1rem 0;
+}
+
+.brand {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.brand a {
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.tagline {
+  margin: 0.35rem 0 0;
+  color: #4e5a53;
+  font-size: 0.95rem;
+}
+
+.content {
+  padding: 1.5rem 0;
+}
+
+.hero {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1.25rem;
+}
+
+.hero h2 {
+  margin-top: 0;
+}
+
+.notice {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.site-footer {
+  padding: 1.25rem 0 2rem;
+  color: #5f685f;
+}
+
+@media (max-width: 600px) {
+  .brand {
+    font-size: 1.05rem;
+  }
+
+  .tagline {
+    font-size: 0.88rem;
+  }
+
+  .hero {
+    padding: 1rem;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Fictions Flow SNS{% endblock %}</title>
+  {% load static %}
+  <link rel="stylesheet" href="{% static 'css/base.css' %}">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1 class="brand"><a href="/">Fictions Flow SNS</a></h1>
+      <p class="tagline">物語世界とキャラクターを育てるSNS</p>
+    </div>
+  </header>
+
+  <main class="container content">
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <small>© Fictions Flow SNS</small>
+    </div>
+  </footer>
+</body>
+</html>

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}ホーム | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero">
+  <h2>ようこそ、Fictions Flow SNSへ</h2>
+  <p>このアプリでは、あなたのWorldとCharacterを管理して、物語投稿へつなげていきます。</p>
+  <p class="notice">現在はMilestone 2の土台を実装中です。</p>
+</section>
+{% endblock %}


### PR DESCRIPTION
## 概要
- global templates ディレクトリを有効化
- base.html を追加
- homeトップをテンプレート返却へ変更
- static/css/base.css を追加（最小モバイル対応）

## 動作確認
- python manage.py check -> OK
- GET / で HTML が返ることを確認

## 関連Issue
- closes #7