### PR TITLE
M2-01: Django標準認証の実装（登録・ログイン・ログアウト）

### DIFF
--- a/fiction_sns/settings.py
+++ b/fiction_sns/settings.py
@@ -51,6 +51,8 @@ INSTALLED_APPS = [
 ]
 
 AUTH_USER_MODEL = 'users.CustomUser'
+LOGIN_REDIRECT_URL = 'dashboard'
+LOGOUT_REDIRECT_URL = 'home_index'
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/fiction_sns/urls.py
+++ b/fiction_sns/urls.py
@@ -4,4 +4,6 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('home.urls')),
+    path('users/', include('users.urls')),
+    path('accounts/', include('django.contrib.auth.urls')),
 ]

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -44,6 +44,64 @@ body {
   font-size: 0.95rem;
 }
 
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.8rem;
+  margin-top: 0.9rem;
+}
+
+.nav-links a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.logout-form {
+  margin: 0;
+}
+
+.logout-form button,
+.auth-form button {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.45rem 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.auth-card {
+  max-width: 560px;
+}
+
+.auth-form p {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.9rem;
+}
+
+.auth-form input {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+  font-size: 1rem;
+}
+
+.helptext {
+  font-size: 0.84rem;
+  color: #5f685f;
+}
+
+.errorlist {
+  color: #9b1d20;
+  margin: 0;
+  padding-left: 1rem;
+}
+
 .content {
   padding: 1.5rem 0;
 }
@@ -76,6 +134,11 @@ body {
 
   .tagline {
     font-size: 0.88rem;
+  }
+
+  .nav-links {
+    gap: 0.65rem;
+    margin-top: 0.75rem;
   }
 
   .hero {

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,19 @@
     <div class="container">
       <h1 class="brand"><a href="/">Fictions Flow SNS</a></h1>
       <p class="tagline">物語世界とキャラクターを育てるSNS</p>
+      <nav class="nav-links" aria-label="Main navigation">
+        <a href="/">ホーム</a>
+        {% if user.is_authenticated %}
+          <a href="{% url 'dashboard' %}">ダッシュボード</a>
+          <form method="post" action="{% url 'logout' %}" class="logout-form">
+            {% csrf_token %}
+            <button type="submit">ログアウト</button>
+          </form>
+        {% else %}
+          <a href="{% url 'signup' %}">新規登録</a>
+          <a href="{% url 'login' %}">ログイン</a>
+        {% endif %}
+      </nav>
     </div>
   </header>
 

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}ログイン | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero auth-card">
+  <h2>ログイン</h2>
+  <form method="post" class="auth-form">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">ログイン</button>
+  </form>
+  <p>アカウントがない場合は <a href="{% url 'signup' %}">新規登録</a> へ。</p>
+</section>
+{% endblock %}

--- a/templates/users/dashboard.html
+++ b/templates/users/dashboard.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}ダッシュボード | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero">
+  <h2>ダッシュボード</h2>
+  <p>{{ user.username }} さん、ログイン中です。</p>
+  <p>このページはログイン必須です。</p>
+</section>
+{% endblock %}

--- a/templates/users/signup.html
+++ b/templates/users/signup.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}新規登録 | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero auth-card">
+  <h2>新規登録</h2>
+  <form method="post" class="auth-form">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">登録する</button>
+  </form>
+  <p>すでにアカウントがある場合は <a href="{% url 'login' %}">ログイン</a> へ。</p>
+</section>
+{% endblock %}

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import UserCreationForm
+
+
+class CustomUserCreationForm(UserCreationForm):
+    class Meta:
+        model = get_user_model()
+        fields = ("username", "email")

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("signup/", views.signup, name="signup"),
+    path("dashboard/", views.dashboard, name="dashboard"),
+]

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,24 @@
-from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect, render
 
-# Create your views here.
+from .forms import CustomUserCreationForm
+
+
+def signup(request):
+	if request.user.is_authenticated:
+		return redirect('dashboard')
+
+	if request.method == 'POST':
+		form = CustomUserCreationForm(request.POST)
+		if form.is_valid():
+			form.save()
+			return redirect('login')
+	else:
+		form = CustomUserCreationForm()
+
+	return render(request, 'users/signup.html', {'form': form})
+
+
+@login_required
+def dashboard(request):
+	return render(request, 'users/dashboard.html')


### PR DESCRIPTION
## 概要
- ユーザー登録画面を追加
- ログイン/ログアウト導線を追加
- ログイン必須のダッシュボードを追加

## 動作確認
- python manage.py check -> OK
- /users/signup/ -> 200
- /accounts/login/ -> 200
- /users/dashboard/ (未ログイン) -> 302 でログインへリダイレクト

## 関連Issue
- closes #8