### PR TITLE
fix: localhost 経由のCSRF Originチェックを許可

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@
 
 SECRET_KEY=ここに自分のSECRET_KEYを貼る
 DEBUG=True
+# 例: https://localhost:8000,https://your-codespace-url.githubpreview.dev
+CSRF_TRUSTED_ORIGINS=https://localhost:8000,http://localhost:8000,https://127.0.0.1:8000,http://127.0.0.1:8000

--- a/fiction_sns/settings.py
+++ b/fiction_sns/settings.py
@@ -36,6 +36,15 @@ DEBUG = os.environ.get('DEBUG', 'True') == 'True'
 
 ALLOWED_HOSTS = []
 
+_trusted_origins_env = os.environ.get('CSRF_TRUSTED_ORIGINS', '')
+_trusted_origins = [o.strip() for o in _trusted_origins_env.split(',') if o.strip()]
+CSRF_TRUSTED_ORIGINS = _trusted_origins or [
+    'http://localhost:8000',
+    'https://localhost:8000',
+    'http://127.0.0.1:8000',
+    'https://127.0.0.1:8000',
+]
+
 
 # Application definition
 


### PR DESCRIPTION
## 概要
- CSRF_TRUSTED_ORIGINS を追加
- localhost/127.0.0.1 の http/https をデフォルト許可
- .env.example に CSRF_TRUSTED_ORIGINS の設定例を追加

## 背景
GitHub/VS Code のポート経由で https://localhost:8000 からPOSTした際に、Origin mismatch で403になるため。