### PR TITLE
#22: handle運用実装（自動割当 + 後編集）

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -61,6 +61,10 @@ body {
 .auth-handle {
   color: #3f4b44;
   font-weight: 700;
+  padding: 0.2rem 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #f2ede2;
 }
 
 .logout-form {
@@ -94,6 +98,10 @@ body {
   border-radius: 8px;
   padding: 0.55rem 0.65rem;
   font-size: 1rem;
+}
+
+.auth-form input[name='handle'] {
+  text-transform: lowercase;
 }
 
 .helptext {

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
         <a href="/">ホーム</a>
         {% if user.is_authenticated %}
           <a href="{% url 'dashboard' %}">ダッシュボード</a>
+          <a href="{% url 'profile_settings' %}">プロフィール設定</a>
           <span class="auth-handle">@{{ user.handle|default:user.username }}</span>
           <form method="post" action="{% url 'logout' %}" class="logout-form">
             {% csrf_token %}

--- a/templates/users/dashboard.html
+++ b/templates/users/dashboard.html
@@ -5,7 +5,8 @@
 {% block content %}
 <section class="hero">
   <h2>ダッシュボード</h2>
-  <p>{{ user.username }} さん、ログイン中です。</p>
+  <p>{{ user.display_name|default:user.handle }} さん、ログイン中です。</p>
+  <p>あなたのハンドル: <strong>@{{ user.handle|default:user.username }}</strong></p>
   <p>このページはログイン必須です。</p>
 </section>
 {% endblock %}

--- a/templates/users/profile_settings.html
+++ b/templates/users/profile_settings.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}プロフィール設定 | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero auth-card">
+  <h2>プロフィール設定</h2>
+  <form method="post" class="auth-form">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">更新する</button>
+  </form>
+  <p class="helptext">handle は常に @ なしで保存され、表示時に @ が付きます。</p>
+</section>
+{% endblock %}

--- a/templates/users/signup.html
+++ b/templates/users/signup.html
@@ -5,6 +5,7 @@
 {% block content %}
 <section class="hero auth-card">
   <h2>新規登録</h2>
+  <p class="helptext">ハンドル名が未入力の場合は、自動でランダムなハンドル名が割り当てられます。</p>
   <form method="post" class="auth-form">
     {% csrf_token %}
     {{ form.as_p }}

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
+from django.core.validators import RegexValidator
+from django.utils.crypto import get_random_string
 
 
 User = get_user_model()
@@ -8,7 +10,7 @@ User = get_user_model()
 
 class CustomUserCreationForm(UserCreationForm):
     email = forms.EmailField(label='メールアドレス', required=True)
-    handle = forms.CharField(label='ハンドル名', max_length=30, help_text='@は不要です（英数字と_のみ）')
+    handle = forms.CharField(label='ハンドル名', max_length=30, required=False, help_text='@は不要です（英数字と_のみ、未入力なら自動生成）')
     display_name = forms.CharField(label='表示名', max_length=50, required=False)
 
     class Meta:
@@ -22,16 +24,22 @@ class CustomUserCreationForm(UserCreationForm):
         return email
 
     def clean_handle(self):
-        handle = self.cleaned_data['handle'].strip().lstrip('@').lower()
+        handle = self.cleaned_data.get('handle', '').strip().lstrip('@').lower()
         if not handle:
-            raise forms.ValidationError('ハンドル名を入力してください。')
+            return ''
         if User.objects.filter(handle__iexact=handle).exists():
             raise forms.ValidationError('このハンドル名はすでに使用されています。')
         return handle
 
+    def _generate_unique_handle(self):
+        while True:
+            candidate = f"user_{get_random_string(8, allowed_chars='abcdefghijklmnopqrstuvwxyz0123456789')}"
+            if not User.objects.filter(handle=candidate).exists():
+                return candidate
+
     def save(self, commit=True):
         user = super().save(commit=False)
-        handle = self.cleaned_data['handle']
+        handle = self.cleaned_data['handle'] or self._generate_unique_handle()
         base_username = f'u_{handle}'
         username = base_username
         index = 1
@@ -43,6 +51,39 @@ class CustomUserCreationForm(UserCreationForm):
         user.email = self.cleaned_data['email']
         user.handle = handle
         user.display_name = self.cleaned_data.get('display_name', '').strip() or handle
+        if commit:
+            user.save()
+        return user
+
+
+class ProfileSettingsForm(forms.ModelForm):
+    handle = forms.CharField(
+        label='ハンドル名',
+        max_length=30,
+        validators=[RegexValidator(regex=r'^[A-Za-z0-9_]+$', message='handleは英数字とアンダースコアのみ使用できます。')],
+        help_text='@は不要です。英数字と_のみ利用できます。',
+    )
+    display_name = forms.CharField(label='表示名', max_length=50, required=False)
+
+    class Meta:
+        model = User
+        fields = ('handle', 'display_name')
+
+    def clean_handle(self):
+        handle = self.cleaned_data['handle'].strip().lstrip('@').lower()
+        if len(handle) < 3:
+            raise forms.ValidationError('handleは3文字以上で入力してください。')
+        if len(handle) > 20:
+            raise forms.ValidationError('handleは20文字以下で入力してください。')
+
+        exists = User.objects.filter(handle__iexact=handle).exclude(pk=self.instance.pk).exists()
+        if exists:
+            raise forms.ValidationError('このハンドル名はすでに使用されています。')
+        return handle
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.display_name = self.cleaned_data.get('display_name', '').strip() or user.handle
         if commit:
             user.save()
         return user

--- a/users/urls.py
+++ b/users/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     path("signup/", views.signup, name="signup"),
     path("dashboard/", views.dashboard, name="dashboard"),
+    path("settings/", views.profile_settings, name="profile_settings"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -2,29 +2,46 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView
 from django.shortcuts import redirect, render
 
-from .forms import CustomUserCreationForm, EmailOrHandleAuthenticationForm
+from .forms import (
+	CustomUserCreationForm,
+	EmailOrHandleAuthenticationForm,
+	ProfileSettingsForm,
+)
 
 
 class CustomLoginView(LoginView):
-	template_name = 'registration/login.html'
-	authentication_form = EmailOrHandleAuthenticationForm
+    template_name = 'registration/login.html'
+    authentication_form = EmailOrHandleAuthenticationForm
 
 
 def signup(request):
-	if request.user.is_authenticated:
-		return redirect('dashboard')
+    if request.user.is_authenticated:
+        return redirect('dashboard')
 
-	if request.method == 'POST':
-		form = CustomUserCreationForm(request.POST)
-		if form.is_valid():
-			form.save()
-			return redirect('login')
-	else:
-		form = CustomUserCreationForm()
+    if request.method == 'POST':
+        form = CustomUserCreationForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('login')
+    else:
+        form = CustomUserCreationForm()
 
-	return render(request, 'users/signup.html', {'form': form})
+    return render(request, 'users/signup.html', {'form': form})
 
 
 @login_required
 def dashboard(request):
 	return render(request, 'users/dashboard.html')
+
+
+@login_required
+def profile_settings(request):
+	if request.method == 'POST':
+		form = ProfileSettingsForm(request.POST, instance=request.user)
+		if form.is_valid():
+			form.save()
+			return redirect('dashboard')
+	else:
+		form = ProfileSettingsForm(instance=request.user)
+
+	return render(request, 'users/profile_settings.html', {'form': form})


### PR DESCRIPTION
## 概要
- サインアップ時、handle未入力ならランダム割当
- プロフィール設定画面を追加（handle/display_name編集）
- handle重複チェック・文字種チェックを実装
- 画面表示を @handle 基準で統一

## 動作確認
- python manage.py check -> OK
- handle未入力でsignup -> 自動生成OK
- handle重複で更新 -> バリデーションエラー
- 一意handleで更新 -> OK

## 関連Issue
- closes #22