### PR TITLE
M2-03: World一覧・作成・編集・削除画面の実装

### DIFF
--- a/fiction_sns/urls.py
+++ b/fiction_sns/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('home.urls')),
     path('users/', include('users.urls')),
+    path('worlds/', include('worlds.urls')),
     path('accounts/login/', CustomLoginView.as_view(), name='login'),
     path('accounts/', include('django.contrib.auth.urls')),
 ]

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -135,6 +135,68 @@ body {
   font-weight: 600;
 }
 
+.world-hero-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.action-link {
+  display: inline-block;
+  text-decoration: none;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  border-radius: 8px;
+  padding: 0.4rem 0.7rem;
+  font-weight: 700;
+}
+
+.world-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.world-item {
+  background: #fdfaf4;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.world-item h3 {
+  margin: 0 0 0.45rem;
+}
+
+.world-item p {
+  margin: 0 0 0.45rem;
+  white-space: pre-wrap;
+}
+
+.world-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 4rem;
+}
+
+.world-actions a {
+  text-decoration: none;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.danger-link {
+  color: #9b1d20 !important;
+}
+
 .site-footer {
   padding: 1.25rem 0 2rem;
   color: #5f685f;
@@ -152,6 +214,19 @@ body {
   .nav-links {
     gap: 0.65rem;
     margin-top: 0.75rem;
+  }
+
+  .world-hero-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .world-item {
+    flex-direction: column;
+  }
+
+  .world-actions {
+    flex-direction: row;
   }
 
   .hero {

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
         <a href="/">ホーム</a>
         {% if user.is_authenticated %}
           <a href="{% url 'dashboard' %}">ダッシュボード</a>
+          <a href="{% url 'world_list' %}">World一覧</a>
           <a href="{% url 'profile_settings' %}">プロフィール設定</a>
           <span class="auth-handle">@{{ user.handle|default:user.username }}</span>
           <form method="post" action="{% url 'logout' %}" class="logout-form">

--- a/templates/worlds/world_confirm_delete.html
+++ b/templates/worlds/world_confirm_delete.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}World削除確認 | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero auth-card">
+  <h2>Worldを削除しますか？</h2>
+  <p>対象: <strong>{{ world.title }}</strong></p>
+  <p>この操作は取り消せません。</p>
+
+  <form method="post" class="auth-form">
+    {% csrf_token %}
+    <button type="submit">削除する</button>
+  </form>
+
+  <p><a href="{% url 'world_list' %}">キャンセルして戻る</a></p>
+</section>
+{% endblock %}

--- a/templates/worlds/world_form.html
+++ b/templates/worlds/world_form.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}
+{% if mode == "create" %}World作成{% else %}World編集{% endif %} | Fictions Flow SNS
+{% endblock %}
+
+{% block content %}
+<section class="hero auth-card">
+  {% if mode == "create" %}
+    <h2>Worldを作成</h2>
+  {% else %}
+    <h2>Worldを編集</h2>
+  {% endif %}
+
+  <form method="post" class="auth-form">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">保存する</button>
+  </form>
+
+  <p><a href="{% url 'world_list' %}">一覧へ戻る</a></p>
+</section>
+{% endblock %}

--- a/templates/worlds/world_list.html
+++ b/templates/worlds/world_list.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}World一覧 | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero world-hero">
+  <div class="world-hero-header">
+    <h2>あなたのWorld一覧</h2>
+    <a class="action-link" href="{% url 'world_create' %}">+ 新規作成</a>
+  </div>
+
+  {% if worlds %}
+    <ul class="world-list">
+      {% for world in worlds %}
+        <li class="world-item">
+          <div>
+            <h3>{{ world.title }}</h3>
+            <p>{{ world.description|default:"説明は未設定です。"|linebreaksbr }}</p>
+            <small>作成日: {{ world.created_at|date:"Y-m-d H:i" }}</small>
+          </div>
+          <div class="world-actions">
+            <a href="{% url 'world_edit' world.id %}">編集</a>
+            <a class="danger-link" href="{% url 'world_delete' world.id %}">削除</a>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>まだWorldがありません。最初のWorldを作成しましょう。</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/worlds/forms.py
+++ b/worlds/forms.py
@@ -1,0 +1,17 @@
+from django import forms
+
+from .models import World
+
+
+class WorldForm(forms.ModelForm):
+    class Meta:
+        model = World
+        fields = ('title', 'description')
+        labels = {
+            'title': 'タイトル',
+            'description': '説明',
+        }
+        widgets = {
+            'title': forms.TextInput(attrs={'maxlength': 120}),
+            'description': forms.Textarea(attrs={'rows': 5}),
+        }

--- a/worlds/urls.py
+++ b/worlds/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path('', views.world_list, name='world_list'),
+    path('new/', views.world_create, name='world_create'),
+    path('<int:world_id>/edit/', views.world_edit, name='world_edit'),
+    path('<int:world_id>/delete/', views.world_delete, name='world_delete'),
+]

--- a/worlds/views.py
+++ b/worlds/views.py
@@ -1,3 +1,52 @@
-from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, redirect, render
 
-# Create your views here.
+from .forms import WorldForm
+from .models import World
+
+
+@login_required
+def world_list(request):
+	worlds = World.objects.filter(owner=request.user)
+	return render(request, 'worlds/world_list.html', {'worlds': worlds})
+
+
+@login_required
+def world_create(request):
+	if request.method == 'POST':
+		form = WorldForm(request.POST)
+		if form.is_valid():
+			world = form.save(commit=False)
+			world.owner = request.user
+			world.save()
+			return redirect('world_list')
+	else:
+		form = WorldForm()
+
+	return render(request, 'worlds/world_form.html', {'form': form, 'mode': 'create'})
+
+
+@login_required
+def world_edit(request, world_id):
+	world = get_object_or_404(World, id=world_id, owner=request.user)
+
+	if request.method == 'POST':
+		form = WorldForm(request.POST, instance=world)
+		if form.is_valid():
+			form.save()
+			return redirect('world_list')
+	else:
+		form = WorldForm(instance=world)
+
+	return render(request, 'worlds/world_form.html', {'form': form, 'mode': 'edit', 'world': world})
+
+
+@login_required
+def world_delete(request, world_id):
+	world = get_object_or_404(World, id=world_id, owner=request.user)
+
+	if request.method == 'POST':
+		world.delete()
+		return redirect('world_list')
+
+	return render(request, 'worlds/world_confirm_delete.html', {'world': world})


### PR DESCRIPTION
## 概要
- World CRUD画面を追加
- owner による所有者制限を実装
- 削除確認画面（GET）+ 削除実行（POST）を実装
- モバイル表示で崩れないスタイルを追加

## 動作確認
- /worlds/ で自分のWorldのみ表示
- /worlds/new/ で作成可能
- /worlds/<id>/edit/ で編集可能（他人のIDは404）
- /worlds/<id>/delete/ で確認画面表示後に削除可能

## 関連Issue
- closes #10