### PR TITLE
M2-05: Character一覧・作成・編集・削除画面の実装

### DIFF
--- a/templates/worlds/character_confirm_delete.html
+++ b/templates/worlds/character_confirm_delete.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Character削除確認 | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero auth-card">
+  <h2>Characterを削除しますか？</h2>
+  <p>対象World: <strong>{{ world.title }}</strong></p>
+  <p>対象Character: <strong>{{ character.name }}</strong></p>
+  <p>この操作は取り消せません。</p>
+
+  <form method="post" class="auth-form">
+    {% csrf_token %}
+    <button type="submit">削除する</button>
+  </form>
+
+  <p><a href="{% url 'character_list' world.id %}">キャンセルして戻る</a></p>
+</section>
+{% endblock %}

--- a/templates/worlds/character_form.html
+++ b/templates/worlds/character_form.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}
+{% if mode == "create" %}Character作成{% else %}Character編集{% endif %} | Fictions Flow SNS
+{% endblock %}
+
+{% block content %}
+<section class="hero auth-card">
+  {% if mode == "create" %}
+    <h2>{{ world.title }} にCharacterを追加</h2>
+  {% else %}
+    <h2>{{ world.title }} のCharacterを編集</h2>
+  {% endif %}
+
+  <form method="post" class="auth-form">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">保存する</button>
+  </form>
+
+  <p><a href="{% url 'character_list' world.id %}">一覧へ戻る</a></p>
+</section>
+{% endblock %}

--- a/templates/worlds/character_list.html
+++ b/templates/worlds/character_list.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block title %}Character一覧 | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero world-hero">
+  <div class="world-hero-header">
+    <h2>{{ world.title }} のCharacter一覧</h2>
+    <a class="action-link" href="{% url 'character_create' world.id %}">+ 新規作成</a>
+  </div>
+
+  <p><a href="{% url 'world_list' %}">← World一覧へ戻る</a></p>
+
+  {% if characters %}
+    <ul class="world-list">
+      {% for character in characters %}
+        <li class="world-item">
+          <div>
+            <h3>{{ character.name }}</h3>
+            <p><strong>プロフィール:</strong><br>{{ character.profile|default:"未設定"|linebreaksbr }}</p>
+            <p><strong>性格・口調メモ:</strong><br>{{ character.personality|default:"未設定"|linebreaksbr }}</p>
+            <small>作成日: {{ character.created_at|date:"Y-m-d H:i" }}</small>
+          </div>
+          <div class="world-actions">
+            <a href="{% url 'character_edit' world.id character.id %}">編集</a>
+            <a class="danger-link" href="{% url 'character_delete' world.id character.id %}">削除</a>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>まだCharacterがありません。新規作成しましょう。</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/templates/worlds/world_list.html
+++ b/templates/worlds/world_list.html
@@ -19,6 +19,7 @@
             <small>作成日: {{ world.created_at|date:"Y-m-d H:i" }}</small>
           </div>
           <div class="world-actions">
+            <a href="{% url 'character_list' world.id %}">Character管理</a>
             <a href="{% url 'world_edit' world.id %}">編集</a>
             <a class="danger-link" href="{% url 'world_delete' world.id %}">削除</a>
           </div>

--- a/worlds/forms.py
+++ b/worlds/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from .models import World
+from .models import Character, World
 
 
 class WorldForm(forms.ModelForm):
@@ -14,4 +14,20 @@ class WorldForm(forms.ModelForm):
         widgets = {
             'title': forms.TextInput(attrs={'maxlength': 120}),
             'description': forms.Textarea(attrs={'rows': 5}),
+        }
+
+
+class CharacterForm(forms.ModelForm):
+    class Meta:
+        model = Character
+        fields = ('name', 'profile', 'personality')
+        labels = {
+            'name': '名前',
+            'profile': 'プロフィール',
+            'personality': '性格・口調メモ',
+        }
+        widgets = {
+            'name': forms.TextInput(attrs={'maxlength': 120}),
+            'profile': forms.Textarea(attrs={'rows': 4}),
+            'personality': forms.Textarea(attrs={'rows': 4}),
         }

--- a/worlds/urls.py
+++ b/worlds/urls.py
@@ -7,4 +7,8 @@ urlpatterns = [
     path('new/', views.world_create, name='world_create'),
     path('<int:world_id>/edit/', views.world_edit, name='world_edit'),
     path('<int:world_id>/delete/', views.world_delete, name='world_delete'),
+    path('<int:world_id>/characters/', views.character_list, name='character_list'),
+    path('<int:world_id>/characters/new/', views.character_create, name='character_create'),
+    path('<int:world_id>/characters/<int:character_id>/edit/', views.character_edit, name='character_edit'),
+    path('<int:world_id>/characters/<int:character_id>/delete/', views.character_delete, name='character_delete'),
 ]

--- a/worlds/views.py
+++ b/worlds/views.py
@@ -1,8 +1,8 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 
-from .forms import WorldForm
-from .models import World
+from .forms import CharacterForm, WorldForm
+from .models import Character, World
 
 
 @login_required
@@ -50,3 +50,59 @@ def world_delete(request, world_id):
 		return redirect('world_list')
 
 	return render(request, 'worlds/world_confirm_delete.html', {'world': world})
+
+
+@login_required
+def character_list(request, world_id):
+	world = get_object_or_404(World, id=world_id, owner=request.user)
+	characters = Character.objects.filter(world=world)
+	return render(request, 'worlds/character_list.html', {'world': world, 'characters': characters})
+
+
+@login_required
+def character_create(request, world_id):
+	world = get_object_or_404(World, id=world_id, owner=request.user)
+
+	if request.method == 'POST':
+		form = CharacterForm(request.POST)
+		if form.is_valid():
+			character = form.save(commit=False)
+			character.world = world
+			character.save()
+			return redirect('character_list', world_id=world.id)
+	else:
+		form = CharacterForm()
+
+	return render(request, 'worlds/character_form.html', {'form': form, 'mode': 'create', 'world': world})
+
+
+@login_required
+def character_edit(request, world_id, character_id):
+	world = get_object_or_404(World, id=world_id, owner=request.user)
+	character = get_object_or_404(Character, id=character_id, world=world)
+
+	if request.method == 'POST':
+		form = CharacterForm(request.POST, instance=character)
+		if form.is_valid():
+			form.save()
+			return redirect('character_list', world_id=world.id)
+	else:
+		form = CharacterForm(instance=character)
+
+	return render(
+		request,
+		'worlds/character_form.html',
+		{'form': form, 'mode': 'edit', 'world': world, 'character': character},
+	)
+
+
+@login_required
+def character_delete(request, world_id, character_id):
+	world = get_object_or_404(World, id=world_id, owner=request.user)
+	character = get_object_or_404(Character, id=character_id, world=world)
+
+	if request.method == 'POST':
+		character.delete()
+		return redirect('character_list', world_id=world.id)
+
+	return render(request, 'worlds/character_confirm_delete.html', {'world': world, 'character': character})


### PR DESCRIPTION
## 概要
- Character CRUD 画面を追加
- World所有者制限（自分のWorld配下のみ操作可）を実装
- 削除確認画面を追加

## 画面
- /worlds/<world_id>/characters/
- /worlds/<world_id>/characters/new/
- /worlds/<world_id>/characters/<id>/edit/
- /worlds/<world_id>/characters/<id>/delete/

## 動作確認
- 一覧で自分のWorldのCharacterのみ表示
- 作成・編集・削除が動作
- 他人World配下の編集アクセスは404
- 削除は確認画面経由で実行

## 関連Issue
- closes #12