### PR TITLE
M3-02: World公開閲覧 + タイムライン表示（新着順）

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -197,6 +197,35 @@ body {
   color: #9b1d20 !important;
 }
 
+.timeline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.timeline-item {
+  background: #fdfaf4;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.9rem;
+}
+
+.timeline-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: baseline;
+  margin-bottom: 0.45rem;
+  color: #4f5952;
+}
+
+.timeline-item p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
 .site-footer {
   padding: 1.25rem 0 2rem;
   color: #5f685f;

--- a/templates/worlds/world_list.html
+++ b/templates/worlds/world_list.html
@@ -19,6 +19,7 @@
             <small>作成日: {{ world.created_at|date:"Y-m-d H:i" }}</small>
           </div>
           <div class="world-actions">
+            <a href="{% url 'world_timeline' world.id %}">タイムライン</a>
             <a href="{% url 'character_list' world.id %}">Character管理</a>
             <a href="{% url 'world_edit' world.id %}">編集</a>
             <a class="danger-link" href="{% url 'world_delete' world.id %}">削除</a>

--- a/templates/worlds/world_timeline.html
+++ b/templates/worlds/world_timeline.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}{{ world.title }} タイムライン | Fictions Flow SNS{% endblock %}
+
+{% block content %}
+<section class="hero world-hero">
+  <div class="world-hero-header">
+    <h2>{{ world.title }} タイムライン</h2>
+  </div>
+
+  <p>{{ world.description|default:"このWorldの説明は未設定です。" }}</p>
+
+  {% if posts %}
+    <ul class="timeline-list">
+      {% for post in posts %}
+        <li class="timeline-item">
+          <div class="timeline-meta">
+            <strong>{{ post.character.name }}</strong>
+            <span>@{{ post.author.handle|default:post.author.username }}</span>
+            <small>{{ post.created_at|date:"Y-m-d H:i" }}</small>
+          </div>
+          <p>{{ post.text|linebreaksbr }}</p>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>まだ投稿がありません。</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/worlds/urls.py
+++ b/worlds/urls.py
@@ -5,6 +5,7 @@ from . import views
 urlpatterns = [
     path('', views.world_list, name='world_list'),
     path('new/', views.world_create, name='world_create'),
+    path('<int:world_id>/timeline/', views.world_timeline, name='world_timeline'),
     path('<int:world_id>/edit/', views.world_edit, name='world_edit'),
     path('<int:world_id>/delete/', views.world_delete, name='world_delete'),
     path('<int:world_id>/characters/', views.character_list, name='character_list'),

--- a/worlds/views.py
+++ b/worlds/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 
 from .forms import CharacterForm, WorldForm
-from .models import Character, World
+from .models import Character, Post, World
 
 
 @login_required
@@ -24,6 +24,13 @@ def world_create(request):
 		form = WorldForm()
 
 	return render(request, 'worlds/world_form.html', {'form': form, 'mode': 'create'})
+
+
+@login_required
+def world_timeline(request, world_id):
+	world = get_object_or_404(World, id=world_id)
+	posts = Post.objects.filter(world=world).select_related('character', 'author')
+	return render(request, 'worlds/world_timeline.html', {'world': world, 'posts': posts})
 
 
 @login_required


### PR DESCRIPTION
## 概要
- /worlds/<world_id>/timeline を追加
- ログインユーザー全員にWorldタイムライン閲覧を許可
- Post を created_at DESC で表示
- タイムラインUIをスマホ1カラムで表示

## 動作確認
- 自分/他人のWorldタイムラインを閲覧できる
- 新着順で投稿が表示される
- スマホ幅で可読性がある

## 関連Issue
- closes #30